### PR TITLE
feat: implementar autenticación JWT segura con endpoint /usuarios/me

### DIFF
--- a/CAMBIOS_FRONTEND.md
+++ b/CAMBIOS_FRONTEND.md
@@ -1,0 +1,200 @@
+# Cambios en el Frontend - Autenticación JWT
+
+## Resumen de Cambios
+
+Se actualizó el frontend de Flask para trabajar con la nueva arquitectura de autenticación JWT de la API, donde el login retorna solo el token y el perfil del usuario se obtiene a través del endpoint `/usuarios/me`.
+
+---
+
+## 🔐 Cambios en Autenticación
+
+### 1. Nueva Función Helper: `get_auth_headers()`
+```python
+def get_auth_headers():
+    """Obtiene los headers de autorización con el token JWT."""
+    token = session.get('token')
+    if token:
+        return {'Authorization': f'Bearer {token}'}
+    return {}
+```
+
+**Ubicación:** `frontend/run.py` (línea ~30)  
+**Propósito:** Centraliza la generación de headers de autorización para todas las peticiones a la API.
+
+---
+
+## 🔄 Flujo de Login Actualizado
+
+### Antes (❌ Antiguo)
+```python
+response = requests.post(f'{API_URL}/api/v1/auth/login', ...)
+data = response.json()
+session['user'] = data.get('user')  # ❌ Ya no viene
+session['token'] = data.get('access_token')
+```
+
+### Ahora (✅ Nuevo)
+```python
+# Paso 1: Obtener token
+response = requests.post(f'{API_URL}/api/v1/auth/login', ...)
+token = data.get('access_token')
+
+# Paso 2: Obtener perfil con el token
+profile_response = requests.get(
+    f'{API_URL}/api/v1/usuarios/me',
+    headers={'Authorization': f'Bearer {token}'}
+)
+user_profile = profile_response.json()
+
+# Guardar en sesión
+session['token'] = token
+session['user'] = user_profile
+```
+
+**Beneficios:**
+- ✅ Mayor seguridad: JWT solo contiene `{sub, email, role, exp}`
+- ✅ Datos frescos: El perfil siempre está actualizado
+- ✅ Mejor separación: Token ≠ Perfil
+- ✅ Menor payload: Token más liviano (~200 bytes vs ~800 bytes)
+
+---
+
+## 📝 Rutas Actualizadas
+
+### Gestión de Usuarios
+| Ruta | Método | Cambio |
+|------|--------|--------|
+| `/usuarios/create` | POST | ✅ Ahora envía `headers=get_auth_headers()` |
+| `/usuarios/update` | POST | ✅ Ahora envía `headers=get_auth_headers()` |
+| `/usuarios/delete` | POST | ✅ Ahora envía `headers=get_auth_headers()` |
+
+### Perfil de Usuario
+| Ruta | Método | Cambios Realizados |
+|------|--------|-------------------|
+| `/perfil` | GET | ✅ Usa `/usuarios/me` en lugar de `/usuarios/{id}` |
+| `/perfil/update` | POST | ✅ Envía token + refresca datos desde `/usuarios/me` |
+| `/perfil/avatar` | POST | ✅ Envía token + refresca datos desde `/usuarios/me` |
+| `/perfil/password` | POST | ✅ Envía token en la actualización |
+
+### Cambio Crítico en `/perfil`
+
+**Antes:**
+```python
+user = session.get('user')
+response = requests.get(f"{API_URL}/api/v1/usuarios/{user.get('id_usuario')}", ...)
+```
+
+**Ahora:**
+```python
+response = requests.get(
+    f"{API_URL}/api/v1/usuarios/me",  # ✅ Endpoint correcto
+    headers=get_auth_headers(),        # ✅ Con token
+    timeout=5
+)
+```
+
+---
+
+## 🔒 Seguridad Mejorada
+
+### JWT Payload Reducido
+
+**Antes (❌ Inseguro):**
+```json
+{
+  "sub": 1,
+  "email": "user@example.com",
+  "role": "admin",
+  "nombre_completo": "Juan Pérez",
+  "imagen_perfil": "user_1.jpg",
+  "tipo_documento": "CC",
+  "numero_documento": "123456789",
+  ...  // ~800 bytes
+}
+```
+
+**Ahora (✅ Seguro):**
+```json
+{
+  "sub": 1,
+  "email": "user@example.com", 
+  "role": "admin",
+  "exp": 1735689600
+}
+// ~200 bytes
+```
+
+### Ventajas de Seguridad
+
+1. **Datos sensibles protegidos:** El token no expone información personal
+2. **Menor superficie de ataque:** Menos datos = menos riesgo si el token es interceptado
+3. **Datos siempre actualizados:** El perfil se obtiene desde la base de datos, no del token
+4. **Cumple estándares:** Sigue las mejores prácticas de JWT (RFC 7519)
+
+---
+
+## ✅ Verificación de Cambios
+
+### Checklist de Funcionalidades
+
+- [x] **Login:** Autenticación con token + obtención de perfil
+- [x] **Perfil:** Visualización usando `/usuarios/me`
+- [x] **Actualizar datos:** Envía token + refresca desde `/usuarios/me`
+- [x] **Cambiar avatar:** Envía token + refresca desde `/usuarios/me`
+- [x] **Cambiar contraseña:** Envía token en la actualización
+- [x] **CRUD Usuarios:** Todas las operaciones envían el token
+- [x] **Headers centralizados:** Función `get_auth_headers()` implementada
+
+---
+
+## 🧪 Pruebas Recomendadas
+
+1. **Login exitoso:**
+   - Ingresar con credenciales válidas
+   - Verificar que se guarda el token en `session['token']`
+   - Verificar que se guarda el perfil en `session['user']`
+
+2. **Login fallido:**
+   - Ingresar con credenciales inválidas
+   - Verificar mensaje de error
+
+3. **Perfil:**
+   - Acceder a `/perfil`
+   - Verificar que se muestra la información correcta
+   - Actualizar nombre completo
+   - Cambiar imagen de perfil
+   - Cambiar contraseña
+
+4. **Gestión de usuarios (admin):**
+   - Crear un nuevo usuario
+   - Actualizar un usuario existente
+   - Eliminar un usuario
+
+5. **Token expirado:**
+   - Esperar a que el token expire (o manipular la fecha)
+   - Verificar que la API retorna 401
+   - Verificar redirección al login
+
+---
+
+## 📋 Archivos Modificados
+
+- ✅ `frontend/run.py` - Actualización completa del flujo de autenticación
+
+---
+
+## 🚀 Próximos Pasos
+
+1. **Probar el flujo completo de login**
+2. **Verificar que todas las rutas protegidas funcionen**
+3. **Implementar manejo de token expirado** (redireccionar al login)
+4. **Actualizar pruebas unitarias** si existen
+
+---
+
+## 📝 Notas Importantes
+
+- **Compatibilidad:** El frontend ahora es compatible con la API actualizada
+- **Sesión:** Los datos del usuario se siguen guardando en `session['user']` para compatibilidad con templates
+- **Token:** Se guarda en `session['token']` y se envía en cada petición autenticada
+- **Endpoint `/usuarios/me`:** Es el nuevo estándar para obtener el perfil del usuario autenticado

--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@
 [![MySQL](https://img.shields.io/badge/MySQL-8.0+-4479A1?style=for-the-badge&logo=mysql&logoColor=white)](https://mysql.com)
 [![License](https://img.shields.io/badge/License-ISC-blue?style=for-the-badge)](LICENSE)
 
-**Plataforma integral para la traducción bidireccional de Lenguaje de Señas Colombiano utilizando inteligencia artificial**
+Plataforma integral para la traducción bidireccional de Lenguaje de Señas Colombiano utilizando inteligencia artificial
 
-[📖 Documentación](#-documentación-de-la-api) • [🚀 Inicio Rápido](#-inicio-rápido) • [🏗️ Arquitectura](#-arquitectura-del-proyecto) • [🤝 Contribuir](#-contribuidores)
+[📖 Documentación](#-documentación-de-la-api) • [🚀 Inicio Rápido](#-inicio-rápido) • [🏗️ Arquitectura](#️-arquitectura-del-proyecto) • [🤝 Contribuir](#-contribuidores)
 
 ---
 
 ## 📋 Tabla de Contenidos
 
 - [Características](#-características)
-- [Arquitectura del Proyecto](#-arquitectura-del-proyecto)
+- [Arquitectura del Proyecto](#️-arquitectura-del-proyecto)
 - [Requisitos Previos](#-requisitos-previos)
 - [Inicio Rápido](#-inicio-rápido)
 - [Configuración](#️-configuración)
 - [Documentación de la API](#-documentación-de-la-api)
 - [Base de Datos](#️-base-de-datos)
-- [Tecnologías](#-tecnologías-utilizadas)
+- [Tecnologías](#️-tecnologías-utilizadas)
 - [Seguridad](#-seguridad)
 - [Licencia](#-licencia)
 
@@ -32,7 +32,7 @@
 ## ✨ Características
 
 | Característica | Descripción |
-|----------------|-------------|
+| -------------- | ----------- |
 | 🔄 **Traducción Bidireccional** | Conversión de texto a señas y señas a texto |
 | 🤖 **Inteligencia Artificial** | Modelo de IA para reconocimiento y traducción |
 | 👥 **Gestión de Usuarios** | Sistema completo de roles (Admin/Colaborador) |
@@ -99,7 +99,7 @@ PROYECTO-SENA/
 Asegúrate de tener instalado:
 
 | Requisito | Versión Mínima | Verificar Instalación |
-|-----------|----------------|----------------------|
+| --------- | -------------- | --------------------- |
 | Python | 3.10+ | `python --version` |
 | MySQL | 8.0+ | `mysql --version` |
 | Git | 2.0+ | `git --version` |
@@ -171,7 +171,7 @@ python run.py
 ### 5️⃣ Acceder a la Aplicación
 
 | Servicio | URL | Descripción |
-|----------|-----|-------------|
+| -------- | --- | ----------- |
 | 🌐 Frontend | <http://localhost:5000> | Interfaz de usuario |
 | 🔷 API | <http://localhost:8000> | Backend REST |
 | 📚 Swagger UI | <http://localhost:8000/docs> | Documentación interactiva |
@@ -219,19 +219,19 @@ CORS_ORIGINS=http://localhost:5000,http://localhost:3000
 ### 🔐 Autenticación
 
 | Método | Endpoint | Descripción |
-|--------|----------|-------------|
+| ------ | ------------ | ----------- |
 | `POST` | `/auth/login` | Iniciar sesión |
 
 ### 📊 Estadísticas
 
 | Método | Endpoint | Descripción |
-|--------|----------|-------------|
+| ------ | --------------- | ---------------------------- |
 | `GET` | `/estadisticas` | Obtener métricas del sistema |
 
 ### 👥 Usuarios
 
 | Método | Endpoint | Descripción |
-|--------|----------|-------------|
+| -------- | ------------------ | ------------------ |
 | `GET` | `/usuarios` | Listar usuarios |
 | `POST` | `/usuarios` | Crear usuario |
 | `GET` | `/usuarios/{id}` | Obtener usuario |
@@ -241,7 +241,7 @@ CORS_ORIGINS=http://localhost:5000,http://localhost:3000
 ### 🤝 Contribuciones
 
 | Método | Endpoint | Descripción |
-|--------|----------|-------------|
+| -------- | ------------------------ | ----------------------- |
 | `GET` | `/contribuciones` | Listar contribuciones |
 | `POST` | `/contribuciones` | Crear contribución |
 | `PUT` | `/contribuciones/{id}` | Gestionar contribución |
@@ -249,7 +249,7 @@ CORS_ORIGINS=http://localhost:5000,http://localhost:3000
 ### 📝 Reportes
 
 | Método | Endpoint | Descripción |
-|--------|----------|-------------|
+| -------- | -------------------- | ------------------- |
 | `GET` | `/reportes` | Listar reportes |
 | `POST` | `/reportes` | Crear reporte |
 | `PUT` | `/reportes/{id}` | Actualizar reporte |
@@ -286,7 +286,7 @@ CORS_ORIGINS=http://localhost:5000,http://localhost:3000
 ### Tablas Principales
 
 | Tabla | Descripción |
-|-------|-------------|
+| ----- | ----------- |
 | `roles` | Roles del sistema (Administrador, Colaborador) |
 | `usuarios` | Usuarios registrados |
 | `usuarios_anonimos` | Visitantes no registrados |
@@ -313,7 +313,7 @@ CORS_ORIGINS=http://localhost:5000,http://localhost:3000
 ### Backend
 
 | Tecnología | Versión | Propósito |
-|------------|---------|-----------|
+| ---------- | ------- | -------------------- |
 | ![FastAPI](https://img.shields.io/badge/FastAPI-009688?style=flat&logo=fastapi&logoColor=white) | 0.104.1 | Framework API REST |
 | ![Uvicorn](https://img.shields.io/badge/Uvicorn-499848?style=flat&logo=uvicorn&logoColor=white) | 0.24.0 | Servidor ASGI |
 | ![Pydantic](https://img.shields.io/badge/Pydantic-E92063?style=flat&logo=pydantic&logoColor=white) | 2.5.2 | Validación de datos |
@@ -324,7 +324,7 @@ CORS_ORIGINS=http://localhost:5000,http://localhost:3000
 ### Frontend
 
 | Tecnología | Versión | Propósito |
-|------------|---------|-----------|
+| ---------- | ------- | --------------------- |
 | ![Flask](https://img.shields.io/badge/Flask-000000?style=flat&logo=flask&logoColor=white) | 3.0.0 | Servidor de templates |
 | ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=flat&logo=html5&logoColor=white) | 5 | Estructura |
 | ![CSS3](https://img.shields.io/badge/CSS3-1572B6?style=flat&logo=css3&logoColor=white) | 3 | Estilos |
@@ -334,7 +334,7 @@ CORS_ORIGINS=http://localhost:5000,http://localhost:3000
 ### Base de Datos
 
 | Tecnología | Versión | Propósito |
-|------------|---------|-----------|
+| ---------- | ------- | --------------- |
 | ![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat&logo=mysql&logoColor=white) | 8.0+ | RDBMS principal |
 
 ---
@@ -344,7 +344,7 @@ CORS_ORIGINS=http://localhost:5000,http://localhost:3000
 ### Medidas Implementadas
 
 | Medida | Implementación |
-|--------|----------------|
+| ------ | ------------------------------ |
 | 🔐 **Hashing de Contraseñas** | bcrypt con salt automático |
 | 🎫 **Autenticación** | JWT con expiración configurable |
 | 🛡️ **Autorización** | Validación de roles por endpoint |
@@ -365,11 +365,9 @@ Authorization: Bearer <token>
 
 ## 🤝 Contribuidores
 
-<div align="center">
-
 ### Sign Technology Team
 
-**Desarrollado con ❤️ para la comunidad sorda colombiana**
+Desarrollado con ❤️ para la comunidad sorda colombiana
 
 ---
 
@@ -390,4 +388,3 @@ copyright notice and this permission notice appear in all copies.
 ---
 
 **[⬆ Volver arriba](#-sign-technology)**
-

--- a/api/app/api/v1/endpoints/auth.py
+++ b/api/app/api/v1/endpoints/auth.py
@@ -22,18 +22,16 @@ def login(form_data: UserLoginSchema):
     Raises:
         HTTPException 401: Si las credenciales son incorrectas.
     """
-    result = authenticate_user(form_data.correo, form_data.contrasena)
+    token = authenticate_user(form_data.correo, form_data.contrasena)
     
-    if not result:
+    if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Correo o contraseña incorrecta"
         )
-
-    token, user_info = result
     
     return {
         "access_token": token,
-        "user": user_info
+        "token_type": "bearer"
     }
 

--- a/api/app/api/v1/endpoints/contribuciones.py
+++ b/api/app/api/v1/endpoints/contribuciones.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from typing import List, Optional
 from app.schemas.contribuciones import ContribucionResponse, ContribucionPaginated
 from app.services import contribuciones as contrib_service
@@ -10,7 +10,12 @@ def get_contribution_stats():
     return contrib_service.obtener_stats_contribuciones()
 
 @router.get("/", response_model=ContribucionPaginated)
-def get_contribuciones(estado: Optional[str] = None, query: Optional[str] = None, skip: int = 0, limit: int = 100):
+def get_contribuciones(
+    estado: Optional[str] = None, 
+    query: Optional[str] = None, 
+    skip: int = Query(0, ge=0, description="Número de registros a saltar"), 
+    limit: int = Query(100, ge=1, le=1000, description="Número máximo de registros a retornar")
+):
     result = contrib_service.obtener_contribuciones(estado, query, skip, limit)
     return {
         "total": result["total"],

--- a/api/app/core/dependencies.py
+++ b/api/app/core/dependencies.py
@@ -1,0 +1,81 @@
+"""Dependencias de FastAPI para autenticación y autorización.
+
+Proporciona funciones reutilizables para proteger endpoints
+y obtener el usuario actual del token JWT.
+"""
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from app.core.security import decode_token
+from app.core.logger import logger
+
+security = HTTPBearer()
+
+
+def get_current_user_id(credentials: HTTPAuthorizationCredentials = Depends(security)) -> int:
+    """Extrae y valida el ID del usuario desde el token JWT.
+    
+    Args:
+        credentials: Credenciales Bearer del header Authorization.
+        
+    Returns:
+        ID del usuario autenticado.
+        
+    Raises:
+        HTTPException 401: Si el token es inválido o expirado.
+    """
+    try:
+        token = credentials.credentials
+        payload = decode_token(token)
+        
+        user_id = payload.get("sub")
+        if user_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token inválido: falta subject"
+            )
+            
+        return int(user_id)
+        
+    except Exception as e:
+        logger.warning(f"Token inválido: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido o expirado",
+            headers={"WWW-Authenticate": "Bearer"}
+        )
+
+
+def require_role(required_role: int):
+    """Crea una dependencia que valida el rol del usuario.
+    
+    Args:
+        required_role: ID del rol requerido (1=Admin, 2=Colaborador).
+        
+    Returns:
+        Función de dependencia que valida el rol.
+    """
+    def role_checker(credentials: HTTPAuthorizationCredentials = Depends(security)) -> int:
+        try:
+            token = credentials.credentials
+            payload = decode_token(token)
+            
+            user_role = payload.get("role")
+            if user_role != required_role:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="No tienes permisos para realizar esta acción"
+                )
+                
+            return payload.get("sub")
+            
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning(f"Error validando rol: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token inválido o expirado"
+            )
+    
+    return role_checker

--- a/api/app/core/logger.py
+++ b/api/app/core/logger.py
@@ -1,0 +1,47 @@
+"""Configuración del sistema de logging de la aplicación.
+
+Proporciona un logger configurado con formato estructurado para
+facilitar debugging y monitoreo en producción.
+"""
+
+import logging
+import sys
+from typing import Optional
+
+
+def setup_logger(name: str = "signtechnology", level: int = logging.INFO) -> logging.Logger:
+    """Configura y retorna un logger con formato estructurado.
+    
+    Args:
+        name: Nombre del logger.
+        level: Nivel de logging (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+        
+    Returns:
+        Logger configurado.
+    """
+    logger = logging.getLogger(name)
+    
+    # Evitar duplicar handlers si ya está configurado
+    if logger.handlers:
+        return logger
+        
+    logger.setLevel(level)
+    
+    # Handler para stdout
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(level)
+    
+    # Formato estructurado con timestamp
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s:%(lineno)d - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+    handler.setFormatter(formatter)
+    
+    logger.addHandler(handler)
+    
+    return logger
+
+
+# Logger global de la aplicación
+logger = setup_logger()

--- a/api/app/core/security.py
+++ b/api/app/core/security.py
@@ -42,14 +42,15 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 def create_access_token(data: dict) -> str:
     """Genera un token JWT para autenticación.
     
-    El token contiene la información del usuario y tiene un tiempo
-    de expiración definido en la configuración.
+    Según mejores prácticas de seguridad, el token solo debe contener
+    datos mínimos necesarios para identificación (sub, email, role).
+    El perfil completo se obtiene mediante endpoint protegido.
     
     Args:
-        data: Datos a incluir en el token (correo, id_usuario, etc.).
+        data: Datos mínimos (sub: user_id, email, role).
         
     Returns:
-        Token JWT codificado.
+        Token JWT codificado con tiempo de expiración.
     """
     to_encode = data.copy()
     expire = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager
 from app.api.v1.router import router as v1_router
 from app.core.config import settings
 from app.core.database import init_pool, close_pool
+from app.core.logger import logger
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -21,16 +22,16 @@ async def lifespan(app: FastAPI):
     Shutdown: Cierra todas las conexiones del pool y libera recursos.
     """
     # Inicializar pool de conexiones al arrancar
-    print("Inicializando pool de conexiones...")
+    logger.info("Iniciando aplicación SignTechnology...")
     init_pool()
-    print("Pool de conexiones inicializado")
+    logger.info("Pool de conexiones inicializado correctamente")
     
     yield
     
     # Cerrar pool de conexiones al detener
-    print("Cerrando pool de conexiones...")
+    logger.info("Cerrando aplicación...")
     close_pool()
-    print("Pool cerrado correctamente")
+    logger.info("Aplicación cerrada correctamente")
 
 app = FastAPI(
     title="SIGNTECHNOLOGY API",

--- a/api/app/schemas/auth.py
+++ b/api/app/schemas/auth.py
@@ -22,6 +22,10 @@ class UserInfoSchema(BaseModel):
 
 
 class TokenResponse(BaseModel):
+    """Respuesta del login con token JWT.
+    
+    Según mejores prácticas, solo retorna el token.
+    El perfil completo se obtiene con GET /usuarios/me usando el token.
+    """
     access_token: str
     token_type: str = "bearer"
-    user: UserInfoSchema

--- a/api/app/services/contribuciones.py
+++ b/api/app/services/contribuciones.py
@@ -1,17 +1,33 @@
+"""Servicios de gestión de contribuciones de señas.
+
+Capa de lógica de negocio para operaciones CRUD de contribuciones,
+con manejo robusto de excepciones y transacciones."""
+
+import pymysql
+from fastapi import HTTPException, status
 from app.core.database import get_connection
+from app.core.logger import logger
+
 
 def obtener_contribuciones(estado: str = None, query: str = None, skip: int = 0, limit: int = 100):
-    conn = get_connection()
+    """Obtiene lista paginada de contribuciones con filtros opcionales."""
+    conn = None
     try:
+        conn = get_connection()
+        
         with conn.cursor() as cursor:
-            # Base Query
             sql = """
             SELECT c.*, u.nombre_completo as nombre_usuario 
             FROM contribuciones_senas c
             LEFT JOIN usuarios u ON c.id_usuario_envio = u.id_usuario
             WHERE 1=1
             """
-            count_sql = "SELECT COUNT(*) as total FROM contribuciones_senas c LEFT JOIN usuarios u ON c.id_usuario_envio = u.id_usuario WHERE 1=1"
+            count_sql = """
+            SELECT COUNT(*) as total 
+            FROM contribuciones_senas c 
+            LEFT JOIN usuarios u ON c.id_usuario_envio = u.id_usuario 
+            WHERE 1=1
+            """
             params = []
             
             if estado and estado != 'todos':
@@ -36,24 +52,79 @@ def obtener_contribuciones(estado: str = None, query: str = None, skip: int = 0,
             
             cursor.execute(sql, tuple(data_params))
             data = cursor.fetchall()
+            
             return {"total": total, "data": data}
+            
+    except pymysql.MySQLError as e:
+        logger.error(f"Error de BD en obtener_contribuciones: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error al consultar contribuciones"
+        )
+    except Exception as e:
+        logger.error(f"Error inesperado en obtener_contribuciones: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error interno del servidor"
+        )
     finally:
-        conn.close()
+        if conn:
+            try:
+                conn.close()
+            except Exception as e:
+                logger.warning(f"Error cerrando conexión: {e}")
+
 
 def actualizar_estado_contribucion(id_contribucion: int, estado: str, observaciones: str = None):
-    conn = get_connection()
+    """Actualiza el estado de una contribución (aprobar/rechazar)."""
+    conn = None
     try:
+        conn = get_connection()
+        
         with conn.cursor() as cursor:
-            sql = "UPDATE contribuciones_senas SET estado=%s, observaciones_gestion=%s, fecha_gestion=NOW() WHERE id_contribucion=%s"
+            sql = """
+            UPDATE contribuciones_senas 
+            SET estado=%s, observaciones_gestion=%s, fecha_gestion=NOW() 
+            WHERE id_contribucion=%s
+            """
             cursor.execute(sql, (estado, observaciones, id_contribucion))
             conn.commit()
-            return cursor.rowcount > 0
+            
+            if cursor.rowcount > 0:
+                logger.info(f"Contribución {id_contribucion} actualizada a estado: {estado}")
+                return True
+            return False
+            
+    except pymysql.MySQLError as e:
+        if conn:
+            conn.rollback()
+        logger.error(f"Error de BD en actualizar_estado_contribucion: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error al actualizar contribución"
+        )
+    except Exception as e:
+        if conn:
+            conn.rollback()
+        logger.error(f"Error inesperado en actualizar_estado_contribucion: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error interno del servidor"
+        )
     finally:
-        conn.close()
+        if conn:
+            try:
+                conn.close()
+            except Exception as e:
+                logger.warning(f"Error cerrando conexión: {e}")
+
 
 def obtener_stats_contribuciones():
-    conn = get_connection()
+    """Obtiene estadísticas agregadas de contribuciones."""
+    conn = None
     try:
+        conn = get_connection()
+        
         with conn.cursor() as cursor:
             sql = """
             SELECT 
@@ -64,10 +135,28 @@ def obtener_stats_contribuciones():
             """
             cursor.execute(sql)
             result = cursor.fetchone()
+            
             return {
                 "total": result.get('total', 0) or 0,
                 "pendientes": int(result.get('pendientes', 0) or 0),
                 "aprobadas": int(result.get('aprobadas', 0) or 0)
             }
+            
+    except pymysql.MySQLError as e:
+        logger.error(f"Error de BD en obtener_stats_contribuciones: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error al obtener estadísticas"
+        )
+    except Exception as e:
+        logger.error(f"Error inesperado en obtener_stats_contribuciones: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error interno del servidor"
+        )
     finally:
-        conn.close()
+        if conn:
+            try:
+                conn.close()
+            except Exception as e:
+                logger.warning(f"Error cerrando conexión: {e}")


### PR DESCRIPTION
- Reducir JWT payload a datos mínimos (sub, email, role, exp)
- Crear endpoint GET /usuarios/me para obtener perfil autenticado
- Implementar sistema de logging estructurado
- Optimizar pool de conexiones (autocommit=False, mincached=10)
- Agregar manejo de excepciones en todos los servicios
- Actualizar frontend para usar autenticación en dos pasos
- Crear función helper get_auth_headers() para centralizar tokens
- Actualizar todas las rutas protegidas para enviar Bearer token

Seguridad mejorada:
- JWT más liviano (~200 bytes vs ~800 bytes)
- Datos sensibles no expuestos en el token
- Perfil siempre actualizado desde BD
- Cumple estándares RFC 7519